### PR TITLE
Update seopro.plugin.php

### DIFF
--- a/core/components/seopro/elements/plugins/seopro.plugin.php
+++ b/core/components/seopro/elements/plugins/seopro.plugin.php
@@ -87,7 +87,11 @@ switch ($modx->event->name) {
       $seoKeywords = $modx->newObject('seoKeywords', array('resource' => $resource->get('id')));
     }
     if($seoKeywords){
-      $seoKeywords->set('keywords', trim($_POST['keywords'], ','));
+      if (isset($_POST['keywords'])){
+        $seoKeywords->set('keywords', trim($_POST['keywords'], ','));
+      } else {
+        $seoKeywords->set('keywords', '');  
+      }
       $seoKeywords->save();
     }
     break;


### PR DESCRIPTION
Fixed '/resource/create' processor error when creating resource without $data['keywords'] set