### PR TITLE
Fix globally set generic classes

### DIFF
--- a/assets/components/seopro/css/mgr23.css
+++ b/assets/components/seopro/css/mgr23.css
@@ -127,14 +127,14 @@
     color: #D80000 !important;
 }
 
-.current {
+.seopro-counter .current {
     text-align: right;
     margin-right: 1px;
     display: inline-block;
     width: 21px;
 }
 
-.allowed {
+.seopro-counter .allowed {
     width: 21px;
     display: inline-block;
     text-align: left;


### PR DESCRIPTION
Add the wrapper-class `.seopro-counter ` to the generic classes "current" and "allowed".

Fixes #81 