### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/core/components/seopro/model/seopro/mysql/seokeywords.map.inc.php
+++ b/core/components/seopro/model/seopro/mysql/seokeywords.map.inc.php
@@ -4,7 +4,7 @@
  */
 $xpdo_meta_map['seoKeywords']= array (
   'package' => 'seopro',
-  'version' => NULL,
+  'version' => null,
   'table' => 'seopro_keywords',
   'extends' => 'xPDOSimpleObject',
   'tableMeta' => 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!