### PR TITLE
A plugin should not return any value

### DIFF
--- a/core/components/seopro/elements/plugins/seopro.plugin.php
+++ b/core/components/seopro/elements/plugins/seopro.plugin.php
@@ -6,7 +6,7 @@
  */
 $seoPro = $modx->getService('seopro', 'seoPro', $modx->getOption('seopro.core_path', null, $modx->getOption('core_path') . 'components/seopro/') . 'model/seopro/', $scriptProperties);
 if (!($seoPro instanceof seoPro)) {
-    return '';
+    return;
 }
 
 $disabledTemplates = explode(',', $modx->getOption('seopro.disabledtemplates', null, '0'));


### PR DESCRIPTION
This should avoid such errors in the MODX error log:

```
[2019-10-23 15:08:12] (ERROR @ /.../revolution/core/model/modx/modx.class.php : 1671) [OnMODXInit]1
```